### PR TITLE
Check GDX data errors after gdxDataWriteDone

### DIFF
--- a/src/wgdx.c
+++ b/src/wgdx.c
@@ -1660,8 +1660,8 @@ checkGdxDataErrors (gdxHandle_t gdxH, char *symName, int nColumns,
   int errCount, rc;
   errCount = gdxDataErrorCount (gdxH);
   if (errCount > 0) {
-    /* maximum of 10 error records */
-    char errMsg[GLOBAL_UEL_IDENT_SIZE * GLOBAL_MAX_INDEX_DIM * 10 + 1024];
+    /* maximum of 11 error records */
+    char errMsg[GLOBAL_UEL_IDENT_SIZE * GLOBAL_MAX_INDEX_DIM * 11 + 1024];
     char uel[GLOBAL_UEL_IDENT_SIZE + 1];
     int i, j, status;
 

--- a/src/wgdx.c
+++ b/src/wgdx.c
@@ -806,6 +806,14 @@ registerInputUEL(SEXP sVecVec, int kk, SEXP uelIndex, int *protCount)
 
       rc = gdxUELRegisterStr (gdxHandle, uelString, &gi);
       if (rc != 1) {
+        /* Close GDX file */
+        rc = gdxClose (gdxHandle);
+        if (rc != 0)
+          error("GDXRRW:wgdx:GDXError",
+                "Could not gdxClose: %s", getGDXErrorMsg());
+        (void) gdxFree (&gdxHandle);
+
+        UNPROTECT(*protCount);
         error ("could not register: %s", uelString);
       }
       /* Rprintf("  input: %s  output from gdx: %d\n", uelString, gi); */


### PR DESCRIPTION
We want to check for duplicates after gdxDataWriteDone calls and throw an error in case duplicates exist (data errors are encountered)